### PR TITLE
Improve highlighter contrast in Palenight theme

### DIFF
--- a/themes/palenight/Dark Graphite Text Theme.theme
+++ b/themes/palenight/Dark Graphite Text Theme.theme
@@ -168,7 +168,7 @@
 		<key>kind</key>
 		<string>color</string>
 		<key>value</key>
-		<string>rgba(49, 56, 79, 1.00)</string>
+		<string>rgba(28, 31, 43, 1.00)</string>
 	</dict>
 	<dict>
 		<key>key</key>


### PR DESCRIPTION
Hello there!

Thanks for this amazing theme have been enjoying it for the last couple of months.

## What does this PR do?
Darkens the background of highlighted text in the Palenight theme.

## Context and motivation for this PR
I started using the ::highlighter:: recently and noticed that the Palenight theme has very little background contrast, especially when we compare it to the default Bear templates. This doesn't make the text as notorious as you would expect for something highlighted.

## Screenshots
[Example of contrast in official Bear themes]
![screen shot 2019-02-06 at 11 25 31 pm](https://user-images.githubusercontent.com/5368213/52392606-40954300-2a68-11e9-8a01-d58be3b638ef.png)

[Current contrast]
![screen shot 2019-02-06 at 11 24 16 pm](https://user-images.githubusercontent.com/5368213/52392631-5efb3e80-2a68-11e9-9ed3-43ec8ec1570e.png)

[Proposed contrast] (same as $dark-background-color from App theme)
![screen shot 2019-02-06 at 11 24 39 pm](https://user-images.githubusercontent.com/5368213/52392658-7fc39400-2a68-11e9-9f08-088b0727b7df.png)



This might just be my opinion but hopefully, this makes sense to you.
✌️ 